### PR TITLE
Minor maintenance updates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @sublinks/sublinks-sdk-js

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    rebase-strategy: "disabled"
+
+  # Maintain dependencies for npm
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    rebase-strategy: "disabled"
+    groups:
+      patches:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Reporting Security Issues
+
+The Sublinks team and community take security bugs in Sublinks seriously. We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
+
+To report a security issue, please use the GitHub Security Advisory ["Report a Vulnerability"](https://github.com/sublinks/sublinks-js-client/security/advisories/new) tab.
+
+The Sublinks Core Owner team will send a response indicating the next steps in handling your report. After the initial reply to your report, the team will keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance.
+
+Report security bugs in third-party libraries/modules to the person or team maintaining the library/module.


### PR DESCRIPTION
- Add a SECURITY.md file to provide guidelines for reporting security issues. This will help in the responsible disclosure of security bugs by detailing the process for reporting vulnerabilities. It includes a link to the GitHub Security Advisory for ease of access and ensures contributors are informed about the handling of their reports.
- Add CODEOWNERS set to Sublinks SDJ - JS group
- Add Dependabot for dependency updates